### PR TITLE
Fix ActiveRecord 4 monkeypatch to align with the original code

### DIFF
--- a/lib/new_relic/agent/instrumentation/active_record_notifications.rb
+++ b/lib/new_relic/agent/instrumentation/active_record_notifications.rb
@@ -32,7 +32,7 @@ module NewRelic
               :statement_name => statement_name,
               :binds          => binds) { yield }
           rescue => e
-            raise translate_exception(e, sql)
+            raise translate_exception_class(e, sql)
           end
         end
 


### PR DESCRIPTION
Not sure what happened in https://github.com/newrelic/rpm/commit/04b93b3f72fa16fefe14839b999fffdd3f50b8ee, but the original change introducing the performance improvements in AR instrumentation ended up being broken on AR 4 (you lose AR exception messages when the agent is active).

The original version of this monkeypatched line: https://github.com/rails/rails/blob/4-1-stable/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb#L380